### PR TITLE
refactor(XotBaseListRecords.php): rename imported ListRecords class t…

### DIFF
--- a/Filament/Pages/XotBaseListRecords.php
+++ b/Filament/Pages/XotBaseListRecords.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Modules\Xot\Filament\Pages;
 
-use Filament\Resources\Pages\ListRecords;
+use Filament\Resources\Pages\ListRecords as FilamentListRecords;
 use Illuminate\Support\Str;
 use Modules\UI\Enums\TableLayoutEnum;
 use Modules\UI\Filament\Actions\Table\TableLayoutToggleTableAction;
@@ -18,7 +18,7 @@ use Webmozart\Assert\Assert;
  *
  * @property ?string $model
  */
-abstract class XotBaseListRecords extends ListRecords
+abstract class XotBaseListRecords extends FilamentListRecords
 {
     // use TransTrait; //gia' dentro HasXotTable
     use HasXotTable;

--- a/Filament/Resources/CacheResource/Pages/ListCaches.php
+++ b/Filament/Resources/CacheResource/Pages/ListCaches.php
@@ -4,19 +4,20 @@ declare(strict_types=1);
 
 namespace Modules\Xot\Filament\Resources\CacheResource\Pages;
 
-use Filament\Actions;
 use Filament\Tables;
-use Filament\Tables\Columns\Layout\Stack;
-use Filament\Tables\Enums\ActionsPosition;
-use Filament\Tables\Enums\FiltersLayout;
+use Filament\Actions;
 use Filament\Tables\Table;
 use Modules\UI\Enums\TableLayoutEnum;
-use Modules\UI\Filament\Actions\Table\TableLayoutToggleTableAction;
-use Modules\Xot\Filament\Actions\Header\ArtisanHeaderAction;
-use Modules\Xot\Filament\Resources\CacheResource;
 use Modules\Xot\Filament\Widgets\Clock;
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Columns\Layout\Stack;
+use Filament\Tables\Enums\ActionsPosition;
+use Modules\Xot\Filament\Resources\CacheResource;
+use Modules\Xot\Filament\Pages\XotBaseListRecords;
+use Modules\Xot\Filament\Actions\Header\ArtisanHeaderAction;
+use Modules\UI\Filament\Actions\Table\TableLayoutToggleTableAction;
 
-class ListCaches extends \Modules\Xot\Filament\Pages\XotBaseListRecords
+class ListCaches extends XotBaseListRecords
 {
     public TableLayoutEnum $layoutView = TableLayoutEnum::LIST;
 

--- a/Filament/Resources/LogResource/Pages/ListLogs.php
+++ b/Filament/Resources/LogResource/Pages/ListLogs.php
@@ -6,10 +6,11 @@ namespace Modules\Xot\Filament\Resources\LogResource\Pages;
 
 use Filament\Actions;
 use Modules\UI\Enums\TableLayoutEnum;
-use Modules\UI\Filament\Actions\Table\TableLayoutToggleTableAction;
 use Modules\Xot\Filament\Resources\LogResource;
+use Modules\Xot\Filament\Pages\XotBaseListRecords;
+use Modules\UI\Filament\Actions\Table\TableLayoutToggleTableAction;
 
-class ListLogs extends \Modules\Xot\Filament\Pages\XotBaseListRecords
+class ListLogs extends XotBaseListRecords
 {
     public TableLayoutEnum $layoutView = TableLayoutEnum::LIST;
 

--- a/Filament/Resources/ModuleResource/Pages/ListModules.php
+++ b/Filament/Resources/ModuleResource/Pages/ListModules.php
@@ -4,22 +4,23 @@ declare(strict_types=1);
 
 namespace Modules\Xot\Filament\Resources\ModuleResource\Pages;
 
-use Filament\Actions;
 use Filament\Tables;
-use Filament\Tables\Actions\DeleteAction;
-use Filament\Tables\Actions\DeleteBulkAction;
+use Filament\Actions;
+use Filament\Tables\Table;
+use Nwidart\Modules\Facades\Module;
+use Modules\UI\Enums\TableLayoutEnum;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Actions\DeleteAction;
 use Filament\Tables\Columns\Layout\Stack;
 use Filament\Tables\Enums\ActionsPosition;
-use Filament\Tables\Enums\FiltersLayout;
-use Filament\Tables\Table;
-use Modules\UI\Enums\TableLayoutEnum;
-use Modules\UI\Filament\Actions\Table\TableLayoutToggleTableAction;
+use Filament\Tables\Actions\DeleteBulkAction;
+use Modules\Xot\Filament\Pages\XotBaseListRecords;
 use Modules\Xot\Filament\Resources\ModuleResource;
-use Nwidart\Modules\Facades\Module;
+use Modules\UI\Filament\Actions\Table\TableLayoutToggleTableAction;
 
-class ListModules extends \Modules\Xot\Filament\Pages\XotBaseListRecords
+class ListModules extends XotBaseListRecords
 {
     public TableLayoutEnum $layoutView = TableLayoutEnum::LIST;
 


### PR DESCRIPTION
…o FilamentListRecords for clarity

refactor(ListCaches.php): remove unused imports and organize import statements for better readability
refactor(ListLogs.php): remove unused imports and organize import statements for better readability
refactor(ListModules.php): remove unused imports and organize import statements for better readability